### PR TITLE
Added support for JWT payload audience ('aud')

### DIFF
--- a/jwthenticator/api.py
+++ b/jwthenticator/api.py
@@ -9,7 +9,7 @@ from jwt.utils import force_unicode, to_base64url_uint
 from jwthenticator import schemas
 from jwthenticator.tokens import TokenManager
 from jwthenticator.keys import KeyManager
-from jwthenticator.consts import JWT_ALGORITHM, JWT_ALGORITHM_FAMILY, JWT_LEASE_TIME
+from jwthenticator.consts import JWT_ALGORITHM, JWT_ALGORITHM_FAMILY, JWT_LEASE_TIME, JWT_AUDIENCE
 from jwthenticator.utils import get_rsa_key_pair
 from jwthenticator.exceptions import ExpiredError
 
@@ -23,8 +23,9 @@ class JWThenticatorAPI:
     """
 
     # pylint: disable=too-many-arguments
-    def __init__(self, rsa_key_pair: Tuple[str, Optional[str]] = get_rsa_key_pair(), jwt_lease_time: int = JWT_LEASE_TIME,
-                 jwt_algorithm: str = JWT_ALGORITHM, jwt_algorithm_family: str = JWT_ALGORITHM_FAMILY):
+    def __init__(self, rsa_key_pair: Tuple[str, Optional[str]] = get_rsa_key_pair(),
+                 jwt_lease_time: int = JWT_LEASE_TIME, jwt_algorithm: str = JWT_ALGORITHM,
+                 jwt_algorithm_family: str = JWT_ALGORITHM_FAMILY, jwt_audience: Optional[str] = JWT_AUDIENCE):
         """
         Class can be initiated without giving any parameter, will generate RSA key pair by itself.
         :param rsa_key_pair: (public_key, private_key) RSA key pair. Will generate keys if not given
@@ -33,9 +34,8 @@ class JWThenticatorAPI:
         self.public_key, self._private_key = rsa_key_pair
         self.jwt_algorithm = jwt_algorithm
         self.jwt_algorithm_family = jwt_algorithm_family
-        self.jwt_lease_time = jwt_lease_time
 
-        self.token_manager = TokenManager(self.public_key, self._private_key, self.jwt_algorithm, self.jwt_lease_time)
+        self.token_manager = TokenManager(self.public_key, self._private_key, self.jwt_algorithm, jwt_lease_time, jwt_audience)
         self.key_manager = KeyManager()
 
 

--- a/jwthenticator/consts.py
+++ b/jwthenticator/consts.py
@@ -16,7 +16,7 @@ JWT_ALGORITHM = environ.get("JWT_ALGORITHM", "RS256")
 JWT_ALGORITHM_FAMILY = environ.get("JWT_ALGORITHM_FAMILY", "RSA")
 JWT_LEASE_TIME = int(environ.get("JWT_LEASE_TIME", 30 * 60)) # In seconds - 30 minutes
 RSA_KEY_STRENGTH = int(environ.get("RSA_KEY_STRENGTH", 2048))
-JWT_AUDIENCE = environ.get("JWT_AUDIENCE", "")
+JWT_AUDIENCE = environ.get("JWT_AUDIENCE", None)
 
 # Token consts
 KEY_EXPIRY = int(environ.get("KEY_EXPIRY", DAYS_TO_SECONDS(120)))  # In seconds

--- a/jwthenticator/consts.py
+++ b/jwthenticator/consts.py
@@ -16,6 +16,7 @@ JWT_ALGORITHM = environ.get("JWT_ALGORITHM", "RS256")
 JWT_ALGORITHM_FAMILY = environ.get("JWT_ALGORITHM_FAMILY", "RSA")
 JWT_LEASE_TIME = int(environ.get("JWT_LEASE_TIME", 30 * 60)) # In seconds - 30 minutes
 RSA_KEY_STRENGTH = int(environ.get("RSA_KEY_STRENGTH", 2048))
+JWT_AUDIENCE = environ.get("JWT_AUDIENCE", "")
 
 # Token consts
 KEY_EXPIRY = int(environ.get("KEY_EXPIRY", DAYS_TO_SECONDS(120)))  # In seconds

--- a/jwthenticator/schemas.py
+++ b/jwthenticator/schemas.py
@@ -3,16 +3,28 @@ from __future__ import absolute_import
 
 import uuid
 from dataclasses import field
-from typing import Optional, List, ClassVar, Type
+from typing import Optional, List, ClassVar, Type, Any
 from datetime import datetime
 
-from marshmallow import Schema, fields
-from marshmallow_dataclass import dataclass, NewType
+from marshmallow import Schema, fields, post_dump
+from marshmallow_dataclass import dataclass, NewType, add_schema
 
 from jwthenticator.consts import JWT_ALGORITHM, JWT_ALGORITHM_FAMILY
 
 # Define the UUID type that uses Marshmallow's UUID + Python's UUID
 UUID = NewType("UUID", uuid.UUID, field=fields.UUID)
+
+
+# Marshmallow base schema for skipping None values on dump
+class BaseSchema(Schema):
+    SKIP_VALUES = {None}
+
+    @post_dump
+    def remove_skip_values(self, data: Any, many: bool):
+        return {
+            key: value for key, value in data.items()
+            if value not in self.SKIP_VALUES
+        }
 
 
 # Data dataclasses (that match the sqlalchemy models)
@@ -42,6 +54,8 @@ class RefreshTokenData:
         return self.expires_at > datetime.utcnow()
 
 
+# Skipping None values on dump since aud is optional and can't be None/empty
+@add_schema(base_schema=BaseSchema)
 @dataclass
 class JWTPayloadData:
     Schema: ClassVar[Type[Schema]] = Schema
@@ -49,7 +63,7 @@ class JWTPayloadData:
     identifier: UUID # Machine the JWT was issued to identifier
     iat: int    # Issued at timestamp
     exp: int    # Expires at timestamp
-    aud: str = ""   # JWT Audience
+    aud: Optional[str] = None   # JWT Audience
 
     async def is_valid(self) -> bool:
         return self.exp > datetime.utcnow().timestamp()

--- a/jwthenticator/schemas.py
+++ b/jwthenticator/schemas.py
@@ -49,6 +49,7 @@ class JWTPayloadData:
     identifier: UUID # Machine the JWT was issued to identifier
     iat: int    # Issued at timestamp
     exp: int    # Expires at timestamp
+    aud: str = ""   # JWT Audience
 
     async def is_valid(self) -> bool:
         return self.exp > datetime.utcnow().timestamp()

--- a/jwthenticator/schemas.py
+++ b/jwthenticator/schemas.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 import uuid
 from dataclasses import field
-from typing import Optional, List, ClassVar, Type, Any
+from typing import Optional, List, ClassVar, Type, Dict, Any
 from datetime import datetime
 
 from marshmallow import Schema, fields, post_dump
@@ -21,7 +21,7 @@ class BaseSchema(Schema):
 
     @post_dump
     # pylint: disable=unused-argument
-    def remove_skip_values(self, data: Any, many: bool):
+    def remove_skip_values(self, data: Any, many: bool) -> Dict[Any, Any]:
         return {
             key: value for key, value in data.items()
             if value not in self.SKIP_VALUES

--- a/jwthenticator/schemas.py
+++ b/jwthenticator/schemas.py
@@ -20,6 +20,7 @@ class BaseSchema(Schema):
     SKIP_VALUES = {None}
 
     @post_dump
+    # pylint: disable=unused-argument
     def remove_skip_values(self, data: Any, many: bool):
         return {
             key: value for key, value in data.items()

--- a/jwthenticator/tests/test_integration.py
+++ b/jwthenticator/tests/test_integration.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 import inspect
+from os.path import basename
 from uuid import uuid4
 from http import HTTPStatus
 from typing import Union
@@ -38,8 +39,8 @@ class ContextAwareClient:
 
     async def __call__(self) -> Union[TestClient, ClientSessionType]:
         context = inspect.stack()
-        caller_file = context[1].filename
-        if any([i in caller_file for i in CLIENT_PATCH_FILES]):
+        caller_file = basename(context[1].filename)
+        if caller_file in CLIENT_PATCH_FILES:
             return self.test_client
         return ClientSession()
 

--- a/jwthenticator/tokens.py
+++ b/jwthenticator/tokens.py
@@ -19,6 +19,7 @@ class TokenManager:
     Class responsible for the creation and loading of tokens
     """
 
+    # pylint: disable=too-many-arguments,too-many-instance-attributes
     def __init__(self, public_key: str, private_key: Optional[str] = None, algorithm: str = JWT_ALGORITHM,
                  jwt_lease_time: int = JWT_LEASE_TIME, jwt_audience: Optional[str] = JWT_AUDIENCE):
         """

--- a/jwthenticator/tokens.py
+++ b/jwthenticator/tokens.py
@@ -11,7 +11,7 @@ from asyncalchemy import create_session_factory
 from jwthenticator.models import Base, RefreshTokenInfo
 from jwthenticator.schemas import JWTPayloadData, RefreshTokenData
 from jwthenticator.exceptions import InvalidTokenError, MissingJWTError
-from jwthenticator.consts import JWT_ALGORITHM, REFRESH_TOKEN_EXPIRY, JWT_LEASE_TIME, DB_URI
+from jwthenticator.consts import JWT_ALGORITHM, REFRESH_TOKEN_EXPIRY, JWT_LEASE_TIME, JWT_AUDIENCE, DB_URI
 
 
 class TokenManager:
@@ -19,7 +19,8 @@ class TokenManager:
     Class responsible for the creation and loading of tokens
     """
 
-    def __init__(self, public_key: str, private_key: Optional[str] = None, algorithm: str = JWT_ALGORITHM, jwt_lease_time: int = JWT_LEASE_TIME):
+    def __init__(self, public_key: str, private_key: Optional[str] = None, algorithm: str = JWT_ALGORITHM,
+                 jwt_lease_time: int = JWT_LEASE_TIME, jwt_audience: Optional[str] = JWT_AUDIENCE):
         """
         Accepts public + private key pairs.
         If only public key is given tokens can be loaded but not created.
@@ -32,6 +33,7 @@ class TokenManager:
         self.private_key = private_key
         self.algorithm = algorithm
         self.jwt_lease_time = jwt_lease_time
+        self.jwt_audience = jwt_audience
 
         self.refresh_token_schema = RefreshTokenData.Schema()
         self.jwt_payload_data_schema = JWTPayloadData.Schema()
@@ -52,7 +54,8 @@ class TokenManager:
             token_id=uuid4(),
             identifier=identifier,
             iat=int(now.timestamp()),
-            exp=int((now + timedelta(seconds=self.jwt_lease_time)).timestamp())
+            exp=int((now + timedelta(seconds=self.jwt_lease_time)).timestamp()),
+            aud=self.jwt_audience
         )
         encoded_payload = self.jwt_payload_data_schema.dump(payload)
         token_string = jwt.encode(encoded_payload, self.private_key, self.algorithm)


### PR DESCRIPTION
JWT payloads created by `/authenticate` or `/refresh` API calls can now contain the standardized `aud` (audience) field.\
The audience value can be set via parameter to class `__init__`, or via the new environment variable `JWT_AUDIENCE`.\
The default value is `None` and the field won't exist in the generated JWT payload.