### PR TITLE
Converted JWT Audience to List

### DIFF
--- a/jwthenticator/api.py
+++ b/jwthenticator/api.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
 from hashlib import sha512
 
 from Cryptodome.PublicKey import RSA
@@ -25,7 +25,7 @@ class JWThenticatorAPI:
     # pylint: disable=too-many-arguments
     def __init__(self, rsa_key_pair: Tuple[str, Optional[str]] = get_rsa_key_pair(),
                  jwt_lease_time: int = JWT_LEASE_TIME, jwt_algorithm: str = JWT_ALGORITHM,
-                 jwt_algorithm_family: str = JWT_ALGORITHM_FAMILY, jwt_audience: Optional[str] = JWT_AUDIENCE):
+                 jwt_algorithm_family: str = JWT_ALGORITHM_FAMILY, jwt_audience: List[str] = JWT_AUDIENCE):
         """
         Class can be initiated without giving any parameter, will generate RSA key pair by itself.
         :param rsa_key_pair: (public_key, private_key) RSA key pair. Will generate keys if not given

--- a/jwthenticator/consts.py
+++ b/jwthenticator/consts.py
@@ -17,7 +17,7 @@ DISABLE_INTERNAL_API = env.bool("DISABLE_INTERNAL_API", False)
 JWT_ALGORITHM = env.str("JWT_ALGORITHM", "RS256")
 JWT_ALGORITHM_FAMILY = env.str("JWT_ALGORITHM_FAMILY", "RSA")
 JWT_LEASE_TIME = env.int("JWT_LEASE_TIME", 30 * 60) # In seconds - 30 minutes
-JWT_AUDIENCE = env("JWT_AUDIENCE", None)
+JWT_AUDIENCE = env.list("JWT_AUDIENCE", [])
 
 # Token consts
 KEY_EXPIRY = env.int("KEY_EXPIRY", DAYS_TO_SECONDS(120))  # In seconds

--- a/jwthenticator/schemas.py
+++ b/jwthenticator/schemas.py
@@ -65,7 +65,7 @@ class JWTPayloadData:
     identifier: UUID # Machine the JWT was issued to identifier
     iat: int    # Issued at timestamp
     exp: int    # Expires at timestamp
-    aud: Optional[str] = None   # JWT Audience
+    aud: Optional[List[str]] = None   # JWT Audience
 
     async def is_valid(self) -> bool:
         return self.exp > datetime.utcnow().timestamp()

--- a/jwthenticator/schemas.py
+++ b/jwthenticator/schemas.py
@@ -5,6 +5,7 @@ import uuid
 from dataclasses import field
 from typing import Optional, List, ClassVar, Type, Dict, Any
 from datetime import datetime
+from collections.abc import Hashable
 
 from marshmallow import Schema, fields, post_dump
 from marshmallow_dataclass import dataclass, NewType, add_schema
@@ -24,7 +25,7 @@ class BaseSchema(Schema):
     def remove_skip_values(self, data: Any, many: bool) -> Dict[Any, Any]:
         return {
             key: value for key, value in data.items()
-            if value not in self.SKIP_VALUES
+            if not isinstance(value, Hashable) or value not in self.SKIP_VALUES
         }
 
 

--- a/jwthenticator/tokens.py
+++ b/jwthenticator/tokens.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from typing import Optional
+from typing import Optional, List
 from datetime import datetime, timedelta
 from hashlib import sha512
 from uuid import UUID, uuid4
@@ -21,7 +21,7 @@ class TokenManager:
 
     # pylint: disable=too-many-arguments,too-many-instance-attributes
     def __init__(self, public_key: str, private_key: Optional[str] = None, algorithm: str = JWT_ALGORITHM,
-                 jwt_lease_time: int = JWT_LEASE_TIME, jwt_audience: Optional[str] = JWT_AUDIENCE):
+                 jwt_lease_time: int = JWT_LEASE_TIME, jwt_audience: List[str] = JWT_AUDIENCE):
         """
         Accepts public + private key pairs.
         If only public key is given tokens can be loaded but not created.
@@ -34,7 +34,7 @@ class TokenManager:
         self.private_key = private_key
         self.algorithm = algorithm
         self.jwt_lease_time = jwt_lease_time
-        self.jwt_audience = jwt_audience
+        self.jwt_audience = jwt_audience if len(jwt_audience) > 0 else None
 
         self.refresh_token_schema = RefreshTokenData.Schema()
         self.jwt_payload_data_schema = JWTPayloadData.Schema()


### PR DESCRIPTION
In order to fully support the JWT RFC, the JWT "aud" field now uses and accepts a list instead of string only.