### PR TITLE
Added VSCode Project Configurations

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "JWThenticator Server",
+            "type": "python",
+            "request": "launch",
+            "module": "jwthenticator.server"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "python.testing.pytestEnabled": true,
+    "python.testing.pytestArgs": [
+        "jwthenticator"
+    ],
+    "python.linting.enabled": true,
+    "python.linting.pylintEnabled": true,
+    "python.linting.pylintArgs": ["--enable=F,E,W"],
+    "python.linting.mypyEnabled": true,
+}


### PR DESCRIPTION
The VSCode configs do:
- Enable the linting for the project
- Enable launching tests via VSCode
- Add debug configuration for launching a JWThenticator server