### PR TITLE
Added "kid" field to JWT headers

### DIFF
--- a/jwthenticator/api.py
+++ b/jwthenticator/api.py
@@ -10,7 +10,7 @@ from jwthenticator import schemas
 from jwthenticator.tokens import TokenManager
 from jwthenticator.keys import KeyManager
 from jwthenticator.consts import JWT_ALGORITHM, JWT_ALGORITHM_FAMILY, JWT_LEASE_TIME, JWT_AUDIENCE
-from jwthenticator.utils import get_rsa_key_pair
+from jwthenticator.utils import get_rsa_key_pair, calculate_key_signature
 from jwthenticator.exceptions import ExpiredError
 
 INT_TO_BIG_ENDIAN = lambda x: force_unicode(to_base64url_uint(x))
@@ -34,8 +34,9 @@ class JWThenticatorAPI:
         self.public_key, self._private_key = rsa_key_pair
         self.jwt_algorithm = jwt_algorithm
         self.jwt_algorithm_family = jwt_algorithm_family
+        self.key_signature = calculate_key_signature(self.public_key)
 
-        self.token_manager = TokenManager(self.public_key, self._private_key, self.jwt_algorithm, jwt_lease_time, jwt_audience)
+        self.token_manager = TokenManager(self.public_key, self._private_key, self.jwt_algorithm, jwt_lease_time, jwt_audience, key_id=self.key_signature)
         self.key_manager = KeyManager()
 
 

--- a/jwthenticator/tokens.py
+++ b/jwthenticator/tokens.py
@@ -21,7 +21,7 @@ class TokenManager:
 
     # pylint: disable=too-many-arguments,too-many-instance-attributes
     def __init__(self, public_key: str, private_key: Optional[str] = None, algorithm: str = JWT_ALGORITHM,
-                 jwt_lease_time: int = JWT_LEASE_TIME, jwt_audience: List[str] = JWT_AUDIENCE):
+                 jwt_lease_time: int = JWT_LEASE_TIME, jwt_audience: List[str] = JWT_AUDIENCE, key_id: Optional[str] = None):
         """
         Accepts public + private key pairs.
         If only public key is given tokens can be loaded but not created.
@@ -35,6 +35,7 @@ class TokenManager:
         self.algorithm = algorithm
         self.jwt_lease_time = jwt_lease_time
         self.jwt_audience = jwt_audience if len(jwt_audience) > 0 else None
+        self.jwt_headers = {"kid": key_id} if key_id else None
 
         self.refresh_token_schema = RefreshTokenData.Schema()
         self.jwt_payload_data_schema = JWTPayloadData.Schema()
@@ -59,7 +60,7 @@ class TokenManager:
             aud=self.jwt_audience
         )
         encoded_payload = self.jwt_payload_data_schema.dump(payload)
-        token_string = jwt.encode(encoded_payload, self.private_key, self.algorithm)
+        token_string = jwt.encode(encoded_payload, self.private_key, self.algorithm, headers=self.jwt_headers)
         return token_string.decode()
 
 


### PR DESCRIPTION
`TokenManager` now supports receiving a `key_id` ("kid") param to be added to JWT headers.
`api.py` uses the public keys signature as the keys id.