### PR TITLE
Fixed get_jwks To Return Proper JWKs Values

### DIFF
--- a/jwthenticator/schemas.py
+++ b/jwthenticator/schemas.py
@@ -132,3 +132,9 @@ class JWKPayload:
     alg: str = JWT_ALGORITHM    # Key algorithm
     kty: str = JWT_ALGORITHM_FAMILY # Key algorithm family
     use: str = "sig"    # How key will be used, sig (signature) by default
+
+
+@dataclass
+class JWKSResponse:
+    Schema: ClassVar[Type[Schema]] = Schema
+    keys: List[JWKPayload]

--- a/jwthenticator/schemas.py
+++ b/jwthenticator/schemas.py
@@ -119,7 +119,7 @@ class BoolResponse:
 
 
 @dataclass
-class JWKSResponse:
+class JWKPayload:
     """
     See https://auth0.com/docs/tokens/json-web-tokens/json-web-key-set-properties
     """

--- a/jwthenticator/schemas.py
+++ b/jwthenticator/schemas.py
@@ -119,7 +119,7 @@ class BoolResponse:
 
 
 @dataclass
-class JWKPayload:
+class JWKPayload:   # pylint: disable=too-many-instance-attributes
     """
     See https://auth0.com/docs/tokens/json-web-tokens/json-web-key-set-properties
     """

--- a/jwthenticator/schemas.py
+++ b/jwthenticator/schemas.py
@@ -121,12 +121,14 @@ class BoolResponse:
 @dataclass
 class JWKSResponse:
     """
-    See https://auth0.com/docs/tokens/references/jwks-properties
+    See https://auth0.com/docs/tokens/json-web-tokens/json-web-key-set-properties
     """
     Schema: ClassVar[Type[Schema]] = Schema
-    x5c: List[str]
-    n: bytes
-    e: bytes
-    alg: str = JWT_ALGORITHM
-    kty: str = JWT_ALGORITHM_FAMILY
-    use: str = "sig"
+    x5c: List[str]  # x.509 certificate chain
+    n: bytes    # RSA public key modulus
+    e: bytes    # RSA public key exponent
+    x5t: str    # x.509 SHA-1 thumbprint
+    kid: str    # Unique key identifier
+    alg: str = JWT_ALGORITHM    # Key algorithm
+    kty: str = JWT_ALGORITHM_FAMILY # Key algorithm family
+    use: str = "sig"    # How key will be used, sig (signature) by default


### PR DESCRIPTION
- Fixed `get_jwks` not actually returning a properly formatted JWKs
- Split JWK schema into 2 separate schemas, `JWKPayload` and `JWKSResponse`
- Added missing fields to `JWKPayload`